### PR TITLE
Dockerize/Prepare for Convex deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM golang:1.5-onbuild
+ENV PORT=8000
+ENV INSECURE_PORT=8001

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,5 @@
+senatus:
+  build: .
+  ports:
+    - 80:8001
+    - 443:8000


### PR DESCRIPTION
- Adds a `Dockerfile` and a `docker-compose.yml` which not only allows for easier development in general but is also needed to use https://convox.com/
- Before I was handling http->https redirection with a seperate redirector running behind the `:80` port on the ELB. This was a hacky solution. Instead I'm adding an (optional) `INSECURE_PORT` env var which will simply redirect all traffic to https. 
- Also adds some very simple logging since everyone loves logging. 
