### PR TITLE
Switch to heroku

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,0 @@
-FROM golang:1.5-onbuild
-ENV PORT=8000
-ENV INSECURE_PORT=8001

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: senatus

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,0 @@
-senatus:
-  build: .
-  ports:
-    - 80:8001
-    - 443:8000

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,12 @@
+package: senatus
+import:
+- package: github.com/cozmo/senatus
+  subpackages:
+  - db
+  - handler
+- package: github.com/gorilla/mux
+- package: github.com/gorilla/sessions
+- package: github.com/segmentio/go-env
+- package: gopkg.in/mgo.v2
+  subpackages:
+  - bson


### PR DESCRIPTION
Switch to run on heroku instead of convox. This actually makes it a little easier for others to run this, since it now has a `glide.yml` etc. 
